### PR TITLE
Replace deprecated option in unit test

### DIFF
--- a/tests/unit/three/AddEmployeeModal.spec.js
+++ b/tests/unit/three/AddEmployeeModal.spec.js
@@ -8,7 +8,7 @@ localVue.use(BootstrapVue)
 describe('AddEmployeeModal', () => {
   it('passes up add employee event on button click', () => {
     const wrapper = mount(AddEmployeeModal, {
-      attachToDocument: true,
+      attachTo: document.body,
       localVue,
       propsData: {
         static: true
@@ -18,5 +18,6 @@ describe('AddEmployeeModal', () => {
     const button = wrapper.find('button')
     button.trigger('click')
     expect(wrapper.emitted('add-new-employee')).toBeTruthy()
+    wrapper.destroy()
   })
 })


### PR DESCRIPTION
We must now specify the element we want to attach to when using `mount()` from the test utils, else we will get an error:
![image](https://user-images.githubusercontent.com/2937540/122683979-bb420180-d1d0-11eb-805b-edfad11df995.png)

Now they run without causing an error message:
![image](https://user-images.githubusercontent.com/2937540/122684009-fc3a1600-d1d0-11eb-913e-690ad834afc7.png)


Also, add a call to `wrapper.destroy()`, which we should've been calling as well.

Per: https://vue-test-utils.vuejs.org/api/options.html#attachtodocument

Noticed while testing #50 