### PR TITLE
Exclude Cypress and CI files from coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,28 +7,22 @@ module.exports = {
     '!**/vendor/**',
     '!*.config.js',
     '!**/coverage/**',
-    '!**/tests/**'
+    '!**/tests/**',
+    '!**/cypress/**',
+    '!**/ci/**'
   ],
-  moduleFileExtensions: [
-    'js',
-    'jsx',
-    'json',
-    'vue'
-  ],
+  moduleFileExtensions: ['js', 'jsx', 'json', 'vue'],
   transform: {
     '^.+\\.vue$': 'vue-jest',
-    '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
+    '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$':
+      'jest-transform-stub',
     '^.+\\.jsx?$': 'babel-jest'
   },
-  transformIgnorePatterns: [
-    '/node_modules/'
-  ],
+  transformIgnorePatterns: ['/node_modules/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
-  snapshotSerializers: [
-    'jest-serializer-vue'
-  ],
+  snapshotSerializers: ['jest-serializer-vue'],
   testMatch: [
     '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
   ],


### PR DESCRIPTION
Exclude Cypress and the CI directory from unit test coverage calculations, as neither are relevant there.


Noticed while looking at a recent CI run that code coverage was being run for CI and Cypress directories during _unit_ tests:
![image](https://user-images.githubusercontent.com/2937540/123151166-31dd3a00-d431-11eb-8d4d-45b7d9a0b03d.png)


After these changes, they are no longer included, and coverage is a more accurate representation of how much of the app the tests cover:
![image](https://user-images.githubusercontent.com/2937540/123151176-3570c100-d431-11eb-976b-1cb294c96922.png)

