### PR TITLE
Move extended timeout to initial dynamic elements

### DIFF
--- a/cypress/integration/ProjectOne.spec.js
+++ b/cypress/integration/ProjectOne.spec.js
@@ -9,8 +9,8 @@ context('ProjectOne', () => {
     cy.contains('Project 1').click()
 
     // A bit of waiting may be needed for initial data load
-    cy.get('#chart-group', { timeout: 10000 })
-      .find('path')
+    cy.get('#chart-group')
+      .find('path', { timeout: 10000 })
       .should('have.length', 4)
 
     cy.get('#legend-group')

--- a/cypress/integration/ProjectThree.spec.js
+++ b/cypress/integration/ProjectThree.spec.js
@@ -9,7 +9,7 @@ context('ProjectThree', () => {
     cy.contains('Project 3').click()
 
     cy.get('.graph')
-      .find('.node')
+      .find('.node', { timeout: 10000 })
       .should('have.length', 2)
 
     // TODO: Could really use better attrs to query - ARIA or name?

--- a/cypress/integration/ProjectTwo.spec.js
+++ b/cypress/integration/ProjectTwo.spec.js
@@ -12,8 +12,8 @@ context('ProjectTwo', () => {
     cy.contains('Cycling').click()
 
     // A bit of waiting may be needed for initial data load
-    cy.get('svg', { timeout: 10000 })
-      .find('circle')
+    cy.get('svg')
+      .find('circle', { timeout: 10000 })
       .should('have.length', 4)
 
     cy.get('#cycling')


### PR DESCRIPTION
Make sure that the e2e tests apply to extended timeout to the first _dynamic_ elements (created by d3, and not part of the initial template).

This we do to make sure that we only proceed with additional verifications once we know that we've started rendering 'updates' that include the data from firestore.

## Details

The previous long timeouts were all targeting elements that were a part of the initial templates:

**Project 1**
```vue
  <div class="canvas">
    <svg class="donut-chart" viewbox="0 0 250 250">
      <!-- This class -->
      <g id="chart-group" :transform="`translate(${cent.x}, ${cent.y})`"/>
      <g id="legend-group" :transform="`translate(${this.width + 40}, 10)`"/>
    </svg>
  </div>
```

**Project 2**
```vue
  <b-container fluid>
    <div class="canvas">
      <svg class="line-chart" :width="totalWidth" :height="totalHeight">
	    <!-- This class -->
	    <g class="graph"
          :width="graphWidth"
          :height="graphHeight"
          :transform="`translate(${marginLeft}, ${marginTop})`">
          <g class="x-axis" :transform="`translate(0, ${graphHeight})`"/>
          <g class="y-axis"/>
          <path id="data-line" />
          <g class="dotted-lines">
            <path id="x-hover" class="hover-line"/>
            <path id="y-hover" class="hover-line"/>
          </g>
        </g>
      </svg>
    </div>
  </b-container>
```

**Project 3**
```vue
  <b-container fluid>
    <div class="canvas">
	  <!-- This element -->
      <svg class="organization-diagram" :viewBox="`0 0 ${totalWidth} ${totalHeight}`">
        <g class="graph"
          :width="graphWidth"
          :height="graphHeight"
          :transform="`translate(${marginLeft}, ${marginTop})`">
        </g>
      </svg>
    </div>
  </b-container>
```

This could lead to to the test continuing to the chained `find()` calls before the application had begun to render updates based on firestore data. During local e2e testing, this was most frequently observed on ProjectOne (which runs first with the default sort):
![image](https://user-images.githubusercontent.com/2937540/123486392-eca83c00-d5d9-11eb-90c9-fd8aa287847f.png)
