### PR TITLE
Convert hierarchy example to pure Vue

### DIFF
--- a/src/components/hierarchy/CirclePackChart.vue
+++ b/src/components/hierarchy/CirclePackChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container fluid>
+  <div class="container-fluid">
     <div class="canvas">
       <svg class="circle-pack-chart" :width="totalWidth" :height="totalHeight">
         <g class="graph"
@@ -9,7 +9,7 @@
         </g>
       </svg>
     </div>
-  </b-container>
+  </div>
 </template>
 
 <script>

--- a/src/components/hierarchy/HierarchyExample.vue
+++ b/src/components/hierarchy/HierarchyExample.vue
@@ -1,19 +1,19 @@
 <template>
-  <b-container class="project-background grey px-0" fluid>
-    <b-container class="py-3 justify-content-center">
+  <div class="project-background grey px-0 container" fluid>
+    <div class="py-3 justify-content-center container">
       <h3 class="text-black">Hierarchical Data</h3>
-    </b-container>
-    <b-container class="project-main" fluid>
-      <b-container class="py-2 gray-text-light">
+    </div>
+    <div class="project-main container-fluid">
+      <div class="py-2 gray-text-light container">
         <p>Hierarchy example</p>
-      </b-container>
-      <b-row class="pt-4">
-        <b-col>
+      </div>
+      <div class="row pt-4">
+        <div class="col">
           <circle-pack-chart />
-        </b-col>
-      </b-row>
-    </b-container>
-  </b-container>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
The project we depend on, BootstrapVue, has fallen well behind. As the app is quite small, it seems to make sense to migrate away.

For now we go with pure Vue and maintain Bootstrap, to keep things simple.

This is only the first of several PRs to remove BootstrapVue.