### PR TITLE
Run bundlewatch on PRs

### DIFF
--- a/.github/.bundlewatch.config.js
+++ b/.github/.bundlewatch.config.js
@@ -1,12 +1,16 @@
 module.exports = {
   files: [
     {
-      path: 'dist/**/*.js',
+      path: 'dist/**/app.*.js',
+      maxSize: '50kB'
+    },
+    {
+      path: 'dist/**/app.*.css',
       maxSize: '200kB'
     },
     {
-      path: 'dist/**/*.css',
-      maxSize: '200kB'
+      path: 'dist/**/*-vendors.*.css',
+      maxSize: '50kB'
     },
     {
       path: 'dist/**/*-vendors.*.js',

--- a/.github/.bundlewatch.config.js
+++ b/.github/.bundlewatch.config.js
@@ -1,8 +1,12 @@
 module.exports = {
   files: [
     {
-      path: 'dist/*.js',
-      maxSize: '100kB'
+      path: 'dist/**/*.js',
+      maxSize: '200kB'
+    },
+    {
+      path: 'dist/**/*.css',
+      maxSize: '200kB'
     }
   ]
 }

--- a/.github/.bundlewatch.config.js
+++ b/.github/.bundlewatch.config.js
@@ -7,6 +7,10 @@ module.exports = {
     {
       path: 'dist/**/*.css',
       maxSize: '200kB'
+    },
+    {
+      path: 'dist/**/*-vendors.*.js',
+      maxSize: '390kB'
     }
   ]
 }

--- a/.github/.bundlewatch.config.js
+++ b/.github/.bundlewatch.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  files: [
+    {
+      path: 'dist/*.js',
+      maxSize: '100kB'
+    }
+  ]
+}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Labeler"
+name: "Pull Request Checks"
 on:
   pull_request:
     types: [synchronize, opened]
@@ -15,8 +15,7 @@ jobs:
       
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-        env:
-          NODE_ENV: production
+        # For now, install dev dependencies too, since we rely on vue-cli-service
 
       - uses: jackyef/bundlewatch-gh-action@0.2.0
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,26 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    types: [synchronize, opened]
+
+jobs:
+  check_bundlesize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+        env:
+          NODE_ENV: production
+
+      - uses: jackyef/bundlewatch-gh-action@0.2.0
+        with:
+          build-script: npm run build
+          bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+          bundlewatch-config: .github/.bundlewatch.config.js
+  

--- a/src/firestore/index.js
+++ b/src/firestore/index.js
@@ -6,6 +6,7 @@ export const getDatabase = () => {
   const db = firebase.firestore()
 
   if (process.env.VUE_APP_FIREBASE_HOST === 'emulator') {
+    // eslint-disable-next-line no-console
     console.info('Connecting to Firebase emulator...')
     // Needed due to Cypress, in order to keep communication open to Firebase with
     // Cypress in the middle, per first comment here: https://stackoverflow.com/a/61619639


### PR DESCRIPTION
This should help us keep an eye on bundle size.

For now, we've gone with quite high allowable sizes (basically make sure things don't degrade from where they are now).

It is possible we'll see improvement here though, especially as we drop Bootstrap-Vue, and make some upgrades/finish some migrations.