### PR TITLE
Track bundle size on main

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,5 +1,8 @@
 name: "Pull Request Checks"
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [synchronize, opened]
 


### PR DESCRIPTION
It seems bundlewatch has already identified the correct default branch:
![image](https://user-images.githubusercontent.com/2937540/134561636-cf806fee-79bb-4b94-a49c-072611d7b7e5.png)

...but we were not yet gathering any data for it, which we need for comparisons with bundle sizes on PR branches.

These changes correct that.