### PR TITLE
Explicitly set main as tracked branch (bundlewatch)

### DIFF
--- a/.github/.bundlewatch.config.js
+++ b/.github/.bundlewatch.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  trackBranches: [
+    'main'
+  ],
   files: [
     {
       path: 'dist/**/app.*.js',


### PR DESCRIPTION
For bundlewatch, which was showing a misleading log message that made it seem like it knew what we were using as a default branch:
![image](https://user-images.githubusercontent.com/2937540/134563082-89306537-dbc1-49af-86f5-23108220640e.png)


It then came up with different excuses after we set it up to run on the default branch (currently `main`):
![image](https://user-images.githubusercontent.com/2937540/134563093-6083c8cf-78cf-4d60-86a2-0a849244bb7e.png)

It seems the 404 in the line immediately above should have been what we paid attention to.