### PR TITLE
Fix issue connecting to firebase in local env

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,2 +1,2 @@
 NODE_ENV=development
-VUE_APP_FIREBASE_HOST=emulator
+VUE_APP_FIREBASE_BACKEND=emulator

--- a/src/firestore/index.js
+++ b/src/firestore/index.js
@@ -5,7 +5,7 @@ import 'firebase/compat/firestore'
 export const getDatabase = () => {
   const db = firebase.firestore()
 
-  if (process.env.VUE_APP_FIREBASE_HOST === 'emulator') {
+  if (process.env.VUE_APP_FIREBASE_BACKEND === 'emulator') {
     // eslint-disable-next-line no-console
     console.info('Connecting to Firebase emulator...')
     // Needed due to Cypress, in order to keep communication open to Firebase with


### PR DESCRIPTION
The variable name we had chosen to allow toggling use of the emulator seems to have been clashing with an actual variable used by firebase.

This would cause the host to be overwritten, and we were be unable to connect to firebase with the default local config.

Presumably, this was introduced in the [recent firebase upgrade](https://github.com/AndrewADev/data-viz-d3-and-firebase/pull/98), as the connection to firebase was working not too long ago.

This surfaced in the console as a warning:
![image](https://user-images.githubusercontent.com/2937540/134588138-3d4ee0e6-178f-43d7-837a-a2a1e1fc86d6.png)

which lead to errors like this:
![image](https://user-images.githubusercontent.com/2937540/134588873-4a49969a-4e4f-47aa-9086-c0360f4c5bb4.png)


And in general, none of the charts would load.
