### PR TITLE
De-dupe Bootstrap styles import

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -8,7 +8,7 @@ module.exports = [
   {
     name: 'App CSS',
     path: 'dist/**/app.*.css',
-    limit: '235kB',
+    limit: '1.1kB',
     // prevent injection of style-loader runtime, see last part of:
     // https://github.com/ai/size-limit#config
     webpack: false
@@ -24,6 +24,6 @@ module.exports = [
   {
     name: 'Vendor JS',
     path: 'dist/**/*-vendors.*.js',
-    limit: '492kB'
+    limit: '362kB'
   }
 ]

--- a/src/components/hierarchy/HierarchyExample.vue
+++ b/src/components/hierarchy/HierarchyExample.vue
@@ -39,7 +39,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/bootstrap';
+  @import 'node_modules/bootstrap/scss/functions';
+  @import 'node_modules/bootstrap/scss/variables';
+  @import "node_modules/bootstrap/scss/mixins";
 
   .project-background {
     // background-color: $gray-800;

--- a/src/components/hierarchy/HierarchyExample.vue
+++ b/src/components/hierarchy/HierarchyExample.vue
@@ -39,9 +39,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/functions';
-  @import 'node_modules/bootstrap/scss/variables';
-  @import "node_modules/bootstrap/scss/mixins";
+  @import '@/styles/theming';
 
   .project-background {
     // background-color: $gray-800;

--- a/src/components/one/AddBudgetItem.vue
+++ b/src/components/one/AddBudgetItem.vue
@@ -66,7 +66,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/bootstrap';
+  @import 'node_modules/bootstrap/scss/functions';
+  @import 'node_modules/bootstrap/scss/variables';
+  @import "node_modules/bootstrap/scss/mixins";
 
   .text-indigo {
     color: $indigo;

--- a/src/components/one/AddBudgetItem.vue
+++ b/src/components/one/AddBudgetItem.vue
@@ -66,9 +66,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/functions';
-  @import 'node_modules/bootstrap/scss/variables';
-  @import "node_modules/bootstrap/scss/mixins";
+  @import '@/styles/theming';
 
   .text-indigo {
     color: $indigo;

--- a/src/components/one/ProjectOne.vue
+++ b/src/components/one/ProjectOne.vue
@@ -57,9 +57,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/functions';
-  @import 'node_modules/bootstrap/scss/variables';
-  @import "node_modules/bootstrap/scss/mixins";
+  @import '@/styles/theming';
 
   .project-header {
     background-color: darken($indigo, 10%);

--- a/src/components/one/ProjectOne.vue
+++ b/src/components/one/ProjectOne.vue
@@ -57,7 +57,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/bootstrap';
+  @import 'node_modules/bootstrap/scss/functions';
+  @import 'node_modules/bootstrap/scss/variables';
+  @import "node_modules/bootstrap/scss/mixins";
 
   .project-header {
     background-color: darken($indigo, 10%);

--- a/src/components/three/styles.scss
+++ b/src/components/three/styles.scss
@@ -1,4 +1,6 @@
-@import "node_modules/bootstrap/scss/bootstrap";
+@import "node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/variables";
+@import "node_modules/bootstrap/scss/mixins";
 $darkpink: darken(hotpink, 20%);
 
 .btn-secondary {

--- a/src/components/three/styles.scss
+++ b/src/components/three/styles.scss
@@ -1,6 +1,4 @@
-@import "node_modules/bootstrap/scss/functions";
-@import "node_modules/bootstrap/scss/variables";
-@import "node_modules/bootstrap/scss/mixins";
+@import '@/styles/theming';
 $darkpink: darken(hotpink, 20%);
 
 .btn-secondary {

--- a/src/components/two/ProjectTwo.vue
+++ b/src/components/two/ProjectTwo.vue
@@ -114,9 +114,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import "node_modules/bootstrap/scss/functions";
-  @import "node_modules/bootstrap/scss/variables";
-  @import "node_modules/bootstrap/scss/mixins";
+  @import '@/styles/theming';
 
   $teal-highlight: #00bfa5;
 

--- a/src/components/two/ProjectTwo.vue
+++ b/src/components/two/ProjectTwo.vue
@@ -114,7 +114,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import 'node_modules/bootstrap/scss/bootstrap';
+  @import "node_modules/bootstrap/scss/functions";
+  @import "node_modules/bootstrap/scss/variables";
+  @import "node_modules/bootstrap/scss/mixins";
 
   $teal-highlight: #00bfa5;
 

--- a/src/styles/theming.scss
+++ b/src/styles/theming.scss
@@ -1,0 +1,4 @@
+// Imports needed to customize Bootstrap per: https://getbootstrap.com/docs/4.0/getting-started/theming/#importing
+@import "node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/variables";
+@import "node_modules/bootstrap/scss/mixins";


### PR DESCRIPTION
Fix an issue where we were re-importing bootstrap several times over, leading to a GIGANTIC CSS app bundle.

Now we only import the bits needed needed for theming, as documented here: https://getbootstrap.com/docs/4.0/getting-started/theming/#importing

That seems to be enough for the build to figure out that we only need bootstrap once, and yet we can still keep our styles.

Beyond that, refactor these common imports to a single location.

And, most rewardingly of all, set much stricter size limits for the bundles.