### PR TITLE
Update Core-JS and move to Dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "babel-plugin-inline-dotenv": "^1.6.0",
         "bootstrap": "^4.6.1",
-        "core-js": "^3.21.0",
         "d3": "^5.11.0",
         "d3-svg-legend": "^2.25.6",
         "d3-tip": "^0.9.1",
@@ -32,6 +31,7 @@
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^27.5.1",
+        "core-js": "^3.27.1",
         "cypress": "^9.4.1",
         "eslint": "^6.8.0",
         "eslint-plugin-vue": "^9.8.0",
@@ -12156,10 +12156,10 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-      "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
+      "dev": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -42247,9 +42247,10 @@
       }
     },
     "core-js": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-      "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ=="
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.26.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "babel-plugin-inline-dotenv": "^1.6.0",
     "bootstrap": "^4.6.1",
-    "core-js": "^3.21.0",
     "d3": "^5.11.0",
     "d3-svg-legend": "^2.25.6",
     "d3-tip": "^0.9.1",
@@ -39,6 +38,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^27.5.1",
+    "core-js": "^3.27.1",
     "cypress": "^9.4.1",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^9.8.0",


### PR DESCRIPTION
Update to most recent version.

Also move to dev dependencies, since it isn't needed in main app.

This removes a deprecation warning.