### PR TITLE
Migrate hierarchy example to Composition API 

### DIFF
--- a/src/components/hierarchy/CirclePackChart.vue
+++ b/src/components/hierarchy/CirclePackChart.vue
@@ -5,99 +5,81 @@
         <g class="graph"
           :width="graphWidth"
           :height="graphHeight"
-          :transform="`translate(${marginLeft}, ${marginTop})`">
+          :transform="`translate(${dims.marginLeft}, ${dims.marginTop})`">
         </g>
       </svg>
     </div>
   </div>
 </template>
 
-<script>
-
+<script setup>
 import * as d3 from 'd3'
 
 import { data } from './data'
+import { computed, onMounted, reactive } from 'vue'
 
-export default {
-  name: 'CirclePackChart',
-  data () {
-    return {
-      marginTop: 50,
-      marginRight: 50,
-      marginBottom: 50,
-      marginLeft: 50
-    }
+const props = defineProps({
+  graphHeight: {
+    type: Number,
+    default: 700
   },
-
-  props: {
-    graphHeight: {
-      type: Number,
-      default: 700
-    },
-    graphWidth: {
-      type: Number,
-      default: 960
-    }
-  },
-
-  computed: {
-    totalHeight () {
-      return this.graphHeight + this.marginTop + this.marginBottom
-    },
-    totalWidth () {
-      return this.graphWidth + this.marginRight + this.marginLeft
-    },
-    graph () {
-      return d3.select('.graph')
-    }
-  },
-
-  methods: {
-    drawGraph () {
-      const stratify = d3.stratify()
-        .id(d => d.name)
-        .parentId(d => d.parent)
-
-      const rootNode = stratify(data).sum(d => d.amount)
-
-      const pack = d3.pack()
-        .size([960, 700])
-        .padding(5)
-
-      const bubbleData = pack(rootNode).descendants()
-
-      const color = d3.scaleOrdinal(['#d1c4e9', '#b39ddb', '#9575cd'])
-
-      const nodes = this.graph.selectAll('g')
-        .data(bubbleData)
-        .enter()
-        .append('g')
-        .attr('transform', d => `translate(${d.x}, ${d.y})`)
-
-      nodes.append('circle')
-        .attr('r', d => d.r)
-        .attr('stroke', 'white')
-        .attr('stroke-width', 2)
-        .attr('fill', d => color(d.depth))
-
-      // Filter down to leaf nodes
-      nodes.filter(d => !d.children)
-        .append('text')
-        .attr('text-anchor', 'middle')
-        .attr('dy', '0.3em')
-        .attr('fill', 'white')
-        .style('font-size', d => d.value * 5)
-        .text(d => d.data.name)
-    }
-
-  },
-
-  mounted () {
-    this.drawGraph()
+  graphWidth: {
+    type: Number,
+    default: 960
   }
+})
+
+const graph = computed(() => d3.select('.graph'))
+
+const dims = reactive({
+  marginTop: 50,
+  marginRight: 50,
+  marginBottom: 50,
+  marginLeft: 50
+})
+
+const totalHeight = computed(() => props.graphHeight + dims.marginTop + dims.marginBottom)
+const totalWidth = computed(() => props.graphWidth + dims.marginRight + dims.marginLeft)
+
+const drawGraph = () => {
+  const stratify = d3.stratify()
+    .id(d => d.name)
+    .parentId(d => d.parent)
+
+  const rootNode = stratify(data).sum(d => d.amount)
+
+  const pack = d3.pack()
+    .size([960, 700])
+    .padding(5)
+
+  const bubbleData = pack(rootNode).descendants()
+
+  const color = d3.scaleOrdinal(['#d1c4e9', '#b39ddb', '#9575cd'])
+
+  const nodes = graph.value.selectAll('g')
+    .data(bubbleData)
+    .enter()
+    .append('g')
+    .attr('transform', d => `translate(${d.x}, ${d.y})`)
+
+  nodes.append('circle')
+    .attr('r', d => d.r)
+    .attr('stroke', 'white')
+    .attr('stroke-width', 2)
+    .attr('fill', d => color(d.depth))
+
+  // Filter down to leaf nodes
+  nodes.filter(d => !d.children)
+    .append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dy', '0.3em')
+    .attr('fill', 'white')
+    .style('font-size', d => d.value * 5)
+    .text(d => d.data.name)
 }
+
+onMounted(() => {
+  drawGraph()
+})
+
 </script>
-
-<style lang="scss" scoped>
-
-</style>

--- a/src/components/hierarchy/HierarchyExample.vue
+++ b/src/components/hierarchy/HierarchyExample.vue
@@ -16,26 +16,9 @@
   </div>
 </template>
 
-<script>
-
+<script setup>
 import CirclePackChart from './CirclePackChart.vue'
 
-export default {
-  name: 'HierarchyExample',
-  components: { CirclePackChart },
-  data () {
-    return {
-      error: ''
-    }
-  },
-
-  computed: {
-  },
-
-  methods: {
-  }
-
-}
 </script>
 
 <style lang="scss" scoped>

--- a/src/firestore/index.js
+++ b/src/firestore/index.js
@@ -1,7 +1,5 @@
 import { getFirestore, connectFirestoreEmulator, initializeFirestore } from 'firebase/firestore'
 
-
-
 export const configureDatabase = (app) => {
   let db
 


### PR DESCRIPTION
Convert the hierarchy example (layout and chart) over to the [Composition API](https://vuejs.org/guide/extras/composition-api-faq.html).

Note that the hierarchy example is static, in that it uses hard-coded local data to populate d3 chart. Thus, Firebase is not in use here.