### PR TITLE
Fix Vue 3 compat warnings

### DIFF
--- a/src/components/one/DonutChart.vue
+++ b/src/components/one/DonutChart.vue
@@ -18,6 +18,12 @@ import { collection, doc, deleteDoc, onSnapshot } from 'firebase/firestore'
 export default {
   name: 'DonutChart',
 
+  inject: {
+    firestore: {
+      default: () => ({})
+    }
+  },
+
   props: {
     height: {
       type: Number,
@@ -214,7 +220,7 @@ export default {
   },
 
   mounted () {
-    this.db = this.$firestore
+    this.db = this.firestore
     this.initializeChart()
     this.subscribeFirebaseUpdates()
   }

--- a/src/components/one/ProjectOne.vue
+++ b/src/components/one/ProjectOne.vue
@@ -23,6 +23,13 @@ import { collection, addDoc } from 'firebase/firestore'
 export default {
   name: 'ProjectOne',
   components: { AddBudgetItem, DonutChart },
+
+  inject: {
+    firestore: {
+      default: () => ({})
+    }
+  },
+
   data () {
     return {
       db: {},
@@ -49,7 +56,7 @@ export default {
   },
 
   mounted () {
-    this.db = this.$firestore
+    this.db = this.firestore
 
     this.drawGraph()
   }

--- a/src/components/three/AddEmployeeModal.vue
+++ b/src/components/three/AddEmployeeModal.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     :id="modalId"
-    :static="this.static"
     class="modal"
     ref="main-modal"
     aria-labelledby="add-new-employee-header"
@@ -97,11 +96,6 @@ export default {
     modalId: {
       type: String,
       default: 'add-employee-modal'
-    },
-    // Needed for testing, see: https://stackoverflow.com/a/58539818
-    static: {
-      type: Boolean,
-      default: false
     },
     availableManagers: {
       type: Array,

--- a/src/components/three/OrganizationDiagram.vue
+++ b/src/components/three/OrganizationDiagram.vue
@@ -19,6 +19,13 @@ import { collection, onSnapshot } from 'firebase/firestore'
 
 export default {
   name: 'OrganizationDiagram',
+
+  inject: {
+    firestore: {
+      default: () => ({})
+    }
+  },
+
   data () {
     return {
       marginTop: 50,
@@ -144,7 +151,7 @@ export default {
   },
 
   mounted () {
-    this.db = this.$firestore
+    this.db = this.firestore
     this.subscribeToFirebaseUpdates()
   }
 }

--- a/src/components/three/ProjectThree.vue
+++ b/src/components/three/ProjectThree.vue
@@ -35,6 +35,13 @@ import { collection, addDoc } from 'firebase/firestore'
 export default {
   name: 'ProjectThree',
   components: { AddEmployeeModal, OrganizationDiagram },
+
+  inject: {
+    firestore: {
+      default: () => ({})
+    }
+  },
+
   data () {
     return {
       db: {},
@@ -59,7 +66,7 @@ export default {
   },
 
   mounted () {
-    this.db = this.$firestore
+    this.db = this.firestore
   }
 
 }

--- a/src/components/two/LineChart.vue
+++ b/src/components/two/LineChart.vue
@@ -28,6 +28,13 @@ import { ACTIVITY } from './constants'
 
 export default {
   name: 'LineChart',
+
+  inject: {
+    firestore: {
+      default: () => ({})
+    }
+  },
+
   data () {
     return {
       marginTop: 40,
@@ -212,7 +219,7 @@ export default {
   },
 
   mounted () {
-    this.db = this.$firestore
+    this.db = this.firestore
     this.subscribeToFirebaseUpdates()
     this.drawGraph()
   }

--- a/src/components/two/ProjectTwo.vue
+++ b/src/components/two/ProjectTwo.vue
@@ -52,6 +52,13 @@ import { ACTIVITY } from './constants'
 export default {
   name: 'ProjectTwo',
   components: { LineChart },
+
+  inject: {
+    firestore: {
+      default: () => ({})
+    }
+  },
+
   data () {
     return {
       db: {},
@@ -107,7 +114,7 @@ export default {
   },
 
   mounted () {
-    this.db = this.$firestore
+    this.db = this.firestore
 
     this.drawGraph()
   }

--- a/src/main.js
+++ b/src/main.js
@@ -21,8 +21,9 @@ const dbConfig = {
 
 const firebaseApp = initializeApp(dbConfig)
 
-Vue.prototype.$firestore = configureDatabase(firebaseApp)
+const db = configureDatabase(firebaseApp)
 
 const app = createApp(App)
 app.use(router)
+app.provide('firestore', db)
 app.mount('#app')

--- a/tests/unit/three/AddEmployeeModal.spec.js
+++ b/tests/unit/three/AddEmployeeModal.spec.js
@@ -6,10 +6,7 @@ describe('AddEmployeeModal', () => {
   // i.e. does validation instead of disappearing
   it('does not disappear on button click', () => {
     const wrapper = mount(AddEmployeeModal, {
-      attachTo: document.body,
-      props: {
-        static: true
-      }
+      attachTo: document.body
     })
 
     const button = wrapper.find('button')


### PR DESCRIPTION
Fix Vue 3 compat warnings:
- Attribute coercion
- Prototype-based injection

There is one instance of a warning remaining:
![image](https://github.com/AndrewADev/data-viz-d3-and-firebase/assets/2937540/fcd7173b-9029-4f7d-84e0-0d3f690d909d)

...this shouldn't be problematic though, as `aria-pressed` can be set to [`false`, indicating it is able to be pressed, but not currently pressed.](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed#false)

Contrary to the warning message, disabling this isn't really an option, as that then leads to an error:
![image](https://github.com/AndrewADev/data-viz-d3-and-firebase/assets/2937540/cd32e473-b13a-42e8-b1d6-89c9aae3716e)

That is currently the only remaining warning that I know of within the main app. There are a few more in the tests, that I'm not sure if are related to the Vue version or not.